### PR TITLE
Fix deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         run: pnpm run build
 
       - name: Publish Geometr
-        run: pnpm publish
+        run: pnpm publish --publish-branch stable
 
   github-release:
     needs: npm-release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "geometr",
-  "private": true,
   "version": "0.1.0",
   "type": "module",
   "main": "dist/main.umd.js",


### PR DESCRIPTION
## Description

The deployment should now work. The `package.json` file is no longer marked as `private`, and the `pnpm publish` command now specifies the `stable` branch as the deploy branch.

## Requirements

None.

## Additional changes

None.
