### PR TITLE
Correctly publish on CI using npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         run: pnpm run build
 
       - name: Publish Geometr
-        run: pnpm publish --publish-branch stable
+        run: npm publish
 
   github-release:
     needs: npm-release


### PR DESCRIPTION
## Description

Now the publishing workflow uses `npm` to publish.

## Requirements

None.

## Additional changes

None.
