### PR TITLE
Correctly publish on ci using the npm registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 19.4.0
+          registry-url: https://registry.npmjs.org
 
       - name: Set up pnpm v7.26
         uses: pnpm/action-setup@v2
@@ -40,7 +41,7 @@ jobs:
         run: pnpm run build
 
       - name: Publish Geometr
-        run: npm publish
+        run: pnpm publish --publish-branch stable
 
   github-release:
     needs: npm-release


### PR DESCRIPTION
## Description

The release command now explicitly uses the npm registry.

## Requirements

None.

## Additional changes

None.
