### PR TITLE
Improve glass look

### DIFF
--- a/src/components/application/GApplication.scss
+++ b/src/components/application/GApplication.scss
@@ -8,7 +8,7 @@
   min-height: 100vh;
   position: relative;
   color: colors.$white;
-  background-color: colors.$background;
+  background-color: colors.$black;
   background-image:
     radial-gradient(at 72% 33%, colors.$background-accent-1 0, transparent 49%),
     radial-gradient(at 31% 60%, colors.$background-accent-2 0, transparent 55%);

--- a/src/components/card/GCard.stories.tsx
+++ b/src/components/card/GCard.stories.tsx
@@ -15,6 +15,17 @@ const meta: Meta<typeof GCard> = {
 export default meta;
 
 // Exported Stories
+export const DefaultProp: Story = {
+  parameters: { layout: 'fullscreen' },
+  render: (args) => (
+    <GApplication style={{ padding: '1rem' }} >
+      <GCard {...args}>
+        This card only has the default prop
+      </GCard>
+    </GApplication>
+  ),
+};
+
 export const HeaderAndContent: Story = {
   parameters: { layout: 'fullscreen' },
   render: (args) => (
@@ -29,13 +40,20 @@ export const HeaderAndContent: Story = {
   ),
 };
 
-export const DefaultProp: Story = {
+export const MultipleCards: Story = {
   parameters: { layout: 'fullscreen' },
   render: (args) => (
     <GApplication style={{ padding: '1rem' }} >
-      <GCard {...args}>
-        This card only has a content prop
-      </GCard>
+      {
+        [...Array(12)].map((_, index) => (
+          <GCard {...args} key={index} style={{ 'margin-bottom': '1rem' }} >
+            {{
+              header: () => <>Card number {index + 1}</>,
+              content: () => <>This is the content of the card. It usually is quite large.</>,
+            }}
+          </GCard>
+        ))
+      }
     </GApplication>
   ),
 };

--- a/src/components/glass/GGlass.scss
+++ b/src/components/glass/GGlass.scss
@@ -1,14 +1,12 @@
-@use "sass:color";
-@use "@/styles/variables/colors";
-@use "@/styles/variables/shadows";
+@use "./variables";
 
 .g-glass {
   display: inline-block;
   position: relative;
   padding: 0;
   border-radius: 1rem;
-  background-color: color.change(colors.$background, $alpha: 0.75);
+  background-color: variables.$card-background-color;
   backdrop-filter: blur(1rem) saturate(180%);
-  border: 1px solid color.change(colors.$white, $alpha: 0.125);
-  box-shadow: shadows.$internal-brightness;
+  border: 1px solid variables.$card-border-color;
+  box-shadow: variables.$card-internal-brightness;
 }

--- a/src/components/glass/_variables.scss
+++ b/src/components/glass/_variables.scss
@@ -1,0 +1,9 @@
+@use "sass:color";
+@use "@/styles/variables/colors";
+
+// Colors
+$card-background-color: color.change(colors.$slate, $alpha: 0.55);
+$card-border-color: color.change(colors.$white, $alpha: 0.125);
+
+// Shadows
+$card-internal-brightness: inset 0 0 50px color.change(colors.$white, $alpha: 0.1);

--- a/src/styles/variables/_colors.scss
+++ b/src/styles/variables/_colors.scss
@@ -1,4 +1,8 @@
-$background: rgb(28 31 35);
+// Base colors
+$black: rgb(15 15 15);
+$slate: rgb(28 31 35);
 $white: rgb(255 255 255);
-$background-accent-1: rgb(75 33 84 / 40%);
-$background-accent-2: rgb(26 57 81 / 70%);
+
+// Semantic colors
+$background-accent-1: rgb(75 33 84 / 50%);
+$background-accent-2: rgb(26 57 81 / 80%);

--- a/src/styles/variables/_shadows.scss
+++ b/src/styles/variables/_shadows.scss
@@ -1,4 +1,0 @@
-@use "sass:color";
-@use "@/styles/variables/colors";
-
-$internal-brightness: inset 0 0 50px color.change(colors.$white, $alpha: 0.03);


### PR DESCRIPTION
## Description

The `GGlass` element now has a much more glass-like look and feel to it. It is a bit more transparent and the inset shadow is now stronger. Also, the base background color is now much much darker.

## Requirements

None.

## Additional changes

The CSS variables got moved around a bit. They are now nearer where they are used. Also, the `GCard` section has now a new story, with multiple cards for them to cover the complete background.
