### PR TITLE
Bring scrollbar back

### DIFF
--- a/src/components/application/GApplication.scss
+++ b/src/components/application/GApplication.scss
@@ -15,7 +15,6 @@
 
 .g-application__scroll {
   overflow-y: auto;
-  padding: variables.$application-padding;
   width: 100%;
   height: 100%;
 }
@@ -24,4 +23,5 @@
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
+  padding: variables.$application-padding;
 }

--- a/src/styles/_scrollbar.scss
+++ b/src/styles/_scrollbar.scss
@@ -1,8 +1,0 @@
-*::-webkit-scrollbar {
-  display: none;
-}
-
-* {
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,3 +1,2 @@
 @use "./reset";
-@use "./scrollbar";
 @use "./base";


### PR DESCRIPTION
## Description

The application now has scrollbars.

## Requirements

None.

## Additional changes

The padding is now applied to `g-application__wrapper` instead of to `g-application__scroll`.
