### PR TITLE
Fix glass css variable names

### DIFF
--- a/src/components/glass/GGlass.scss
+++ b/src/components/glass/GGlass.scss
@@ -5,8 +5,8 @@
   position: relative;
   padding: 0;
   border-radius: 1rem;
-  background-color: variables.$card-background-color;
+  background-color: variables.$glass-background-color;
   backdrop-filter: blur(1rem) saturate(180%);
-  border: 1px solid variables.$card-border-color;
-  box-shadow: variables.$card-internal-brightness;
+  border: 1px solid variables.$glass-border-color;
+  box-shadow: variables.$glass-internal-brightness;
 }

--- a/src/components/glass/_variables.scss
+++ b/src/components/glass/_variables.scss
@@ -2,8 +2,8 @@
 @use "@/styles/variables/colors";
 
 // Colors
-$card-background-color: color.change(colors.$slate, $alpha: 0.45);
-$card-border-color: color.change(colors.$white, $alpha: 0.08);
+$glass-background-color: color.change(colors.$slate, $alpha: 0.45);
+$glass-border-color: color.change(colors.$white, $alpha: 0.08);
 
 // Shadows
-$card-internal-brightness: inset 0 0 15px color.change(colors.$white, $alpha: 0.03);
+$glass-internal-brightness: inset 0 0 15px color.change(colors.$white, $alpha: 0.03);


### PR DESCRIPTION
## Description

Some of the variable names for the glass styling was still with the `card` prefix. This Pull Request fixes that.

## Requirements

None.

## Additional changes

None.
