### PR TITLE
Implement design system colors

### DIFF
--- a/src/components/application/GApplication.scss
+++ b/src/components/application/GApplication.scss
@@ -1,4 +1,3 @@
-@use "@/styles/variables/colors";
 @use "./variables";
 
 .g-application {
@@ -6,11 +5,11 @@
   width: 100vw;
   height: 100vh;
   overflow: hidden;
-  color: colors.$white;
-  background-color: colors.$black;
+  color: variables.$text-color;
+  background-color: variables.$background-base;
   background-image:
-    radial-gradient(at 72% 33%, colors.$background-accent-1 0, transparent 49%),
-    radial-gradient(at 31% 60%, colors.$background-accent-2 0, transparent 55%);
+    radial-gradient(at 72% 33%, variables.$background-accent-1 0, transparent 49%),
+    radial-gradient(at 31% 60%, variables.$background-accent-2 0, transparent 55%);
 }
 
 .g-application__scroll {

--- a/src/components/application/_variables.scss
+++ b/src/components/application/_variables.scss
@@ -1,1 +1,11 @@
+@use "sass:color";
+@use "@/styles/variables/colors";
+
+// Colors
+$text-color: colors.$gray-100;
+$background-base: colors.$black-900;
+$background-accent-1: color.change(colors.$purple-900, $alpha: 0.5);
+$background-accent-2: color.change(colors.$sky-blue-900, $alpha: 0.6);
+
+// Spacing
 $application-padding: 1rem;

--- a/src/components/card/GCard.scss
+++ b/src/components/card/GCard.scss
@@ -1,10 +1,9 @@
-@use "@/styles/variables/colors";
 @use "./variables";
 
 .g-card {
   display: block;
   overflow: hidden;
-  color: colors.$white;
+  color: variables.$text-color;
 }
 
 .g-card__header {

--- a/src/components/card/_variables.scss
+++ b/src/components/card/_variables.scss
@@ -1,5 +1,9 @@
 @use "@/styles/tools";
+@use "@/styles/variables/colors";
 @use "@/styles/variables/typography";
+
+// Colors
+$text-color: colors.$gray-100;
 
 // Header
 $card-header-font-size: tools.map-deep-get(typography.$typography, "h6", "size");

--- a/src/components/glass/_variables.scss
+++ b/src/components/glass/_variables.scss
@@ -2,8 +2,8 @@
 @use "@/styles/variables/colors";
 
 // Colors
-$glass-background-color: color.change(colors.$slate, $alpha: 0.45);
-$glass-border-color: color.change(colors.$white, $alpha: 0.08);
+$glass-background-color: color.change(colors.$gray-900, $alpha: 0.45);
+$glass-border-color: color.change(colors.$gray-100, $alpha: 0.08);
 
 // Shadows
-$glass-internal-brightness: inset 0 0 15px color.change(colors.$white, $alpha: 0.03);
+$glass-internal-brightness: inset 0 0 15px color.change(colors.$gray-100, $alpha: 0.03);

--- a/src/styles/variables/_colors.scss
+++ b/src/styles/variables/_colors.scss
@@ -1,8 +1,35 @@
-// Base colors
-$black: rgb(5 5 5);
-$slate: rgb(28 31 35);
-$white: rgb(255 255 255);
+// Black
+$black-900: hsl(0deg 0% 2%);
 
-// Semantic colors
-$background-accent-1: rgb(75 33 84 / 50%);
-$background-accent-2: rgb(26 57 81 / 80%);
+// Gray
+$gray-900: hsl(225deg 7% 11%);
+$gray-800: hsl(240deg 8% 17%);
+$gray-700: hsl(242deg 7% 25%);
+$gray-600: hsl(240deg 8% 40%);
+$gray-500: hsl(225deg 7% 60%);
+$gray-400: hsl(210deg 8% 72%);
+$gray-300: hsl(210deg 8% 85%);
+$gray-200: hsl(210deg 8% 93%);
+$gray-100: hsl(225deg 7% 98%);
+
+// Purple
+$purple-900: hsl(276deg 100% 20%);
+$purple-800: hsl(276deg 100% 33%);
+$purple-700: hsl(276deg 90% 42%);
+$purple-600: hsl(276deg 90% 56%);
+$purple-500: hsl(276deg 100% 67%);
+$purple-400: hsl(276deg 100% 73%);
+$purple-300: hsl(276deg 100% 80%);
+$purple-200: hsl(276deg 100% 87%);
+$purple-100: hsl(276deg 100% 95%);
+
+// Sky Blue
+$sky-blue-900: hsl(206deg 100% 20%);
+$sky-blue-800: hsl(206deg 100% 33%);
+$sky-blue-700: hsl(206deg 90% 42%);
+$sky-blue-600: hsl(206deg 90% 56%);
+$sky-blue-500: hsl(206deg 100% 67%);
+$sky-blue-400: hsl(206deg 100% 73%);
+$sky-blue-300: hsl(206deg 100% 80%);
+$sky-blue-200: hsl(206deg 100% 87%);
+$sky-blue-100: hsl(206deg 100% 95%);


### PR DESCRIPTION
## Description

This PR implements some of the design system colors instead of having colors spread across the project. It also organices the colors a bit better, as now colors are only imported on the `_variables` files, where they are given semantic meaning for the styling to be applied on the component afterwards.

## Requirements

None.

## Additional changes

None.
