### PR TITLE
Move black color to gray

### DIFF
--- a/src/components/application/_variables.scss
+++ b/src/components/application/_variables.scss
@@ -3,7 +3,7 @@
 
 // Colors
 $text-color: colors.$gray-100;
-$background-base: colors.$black-900;
+$background-base: colors.$gray-1000;
 $background-accent-1: color.change(colors.$purple-900, $alpha: 0.5);
 $background-accent-2: color.change(colors.$sky-blue-900, $alpha: 0.6);
 

--- a/src/styles/variables/_colors.scss
+++ b/src/styles/variables/_colors.scss
@@ -1,7 +1,5 @@
-// Black
-$black-900: hsl(0deg 0% 2%);
-
 // Gray
+$gray-1000: hsl(225deg 0% 2%);
 $gray-900: hsl(225deg 7% 11%);
 $gray-800: hsl(240deg 8% 17%);
 $gray-700: hsl(242deg 7% 25%);


### PR DESCRIPTION
## Description

Remove the `black` color category, as the design system moved the only black color to the `gray` category as `gray-1000`.

## Requirements

None.

## Additional changes

None.
