### PR TITLE
Add components and composables entrypoints

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -33,14 +33,30 @@ const app = createApp(App);
 
 # Using the components
 
-To use the components, you can import them directly from the `geometr` package. An example would look like this:
+To use the components, you can import them from the `geometr/components` section of the package. An example would look like this:
 
 ```html
 <script setup lang="ts">
-import { GButton } from 'geometr';
+import { GButton } from 'geometr/components';
 </script>
 
 <template>
-  <GButton text="This is a button, wow" disabled />
+  <GButton>This is a button, wow</GButton>
+</template>
+```
+
+# Using the composables
+
+The Geometr package includes some composables to be used alongside the components. For example, the `useModal` composable provides an `open` ref and functions to open, close and toggle the modal. You can import them from the `geometr/composables`. An example would look like this:
+
+```html
+<script setup lang="ts">
+import { useModal } from 'geometr/composables';
+
+const { opened, toggle } = useModal();
+</script>
+
+<template>
+  <GButton @click="toggle">Toggle the modal</GButton>
 </template>
 ```

--- a/package.json
+++ b/package.json
@@ -10,6 +10,14 @@
       "require": "./dist/main.umd.js",
       "import": "./dist/main.es.js"
     },
+    "./components": {
+      "require": "./dist/components.umd.js",
+      "import": "./dist/components.es.js"
+    },
+    "./composables": {
+      "require": "./dist/composables.umd.js",
+      "import": "./dist/composables.es.js"
+    },
     "./styles": {
       "require": "./dist/style.css",
       "import": "./dist/style.css"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
     lib: {
       entry: [
         resolve(__dirname, 'src', 'main.ts'),
+        resolve(__dirname, 'src', 'components/index.ts'),
+        resolve(__dirname, 'src', 'composables/index.ts'),
         resolve(__dirname, 'src', 'styles.ts'),
       ],
       name: 'geometr',


### PR DESCRIPTION
## Description

There are now more entrypoints, a `/components` entrypoint and a `/composables` entrypoint. Also, the documentation has been updated to reflect this change.

## Requirements

None.

## Additional changes

None.
