### PR TITLE
Fix style export

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.2",
   "type": "module",
   "main": "./dist/main.cjs.js",
+  "module": "./dist/main.es.js",
   "types": "./dist/main.d.ts",
   "exports": {
     ".": {
@@ -21,6 +22,7 @@
       "require": "./dist/composables/main.cjs.js"
     },
     "./styles": {
+      "types": "./dist/style.d.ts",
       "import": "./dist/style.css",
       "require": "./dist/style.css"
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
         main: resolve(__dirname, 'src', 'main.ts'),
         'components/main': resolve(__dirname, 'src', 'components', 'main.ts'),
         'composables/main': resolve(__dirname, 'src', 'composables', 'main.ts'),
+        style: resolve(__dirname, 'src', 'styles.ts'),
       },
       fileName: (format, entryName) => `${entryName}.${format}.js`,
     },


### PR DESCRIPTION
## Description

The `geometr/styles` import now works as expected, modifying the global styling of the browser. Also, there is now a `main` specification for the `package.json` file, and an empty `types` file was declared for `geometr/styles`.

## Requirements

None.

## Additional changes

None.
