### PR TITLE
Fix cards with unusual content distribution

### DIFF
--- a/src/components/card/GCard.stories.tsx
+++ b/src/components/card/GCard.stories.tsx
@@ -41,6 +41,33 @@ export const HeaderAndContent: Story = {
   ),
 };
 
+export const OnlyHeader: Story = {
+  parameters: { layout: 'fullscreen' },
+  render: (args) => (
+    <GApplication>
+      <GCard {...args}>
+        {{
+          header: () => <>This is the title</>,
+        }}
+      </GCard>
+    </GApplication>
+  ),
+};
+
+export const HeaderAndSubtitle: Story = {
+  parameters: { layout: 'fullscreen' },
+  render: (args) => (
+    <GApplication>
+      <GCard {...args}>
+        {{
+          header: () => <>This is the title</>,
+          subtitle: () => <>This is a subtitle</>,
+        }}
+      </GCard>
+    </GApplication>
+  ),
+};
+
 export const HeaderSubtitleAndContent: Story = {
   parameters: { layout: 'fullscreen' },
   render: (args) => (
@@ -56,7 +83,25 @@ export const HeaderSubtitleAndContent: Story = {
   ),
 };
 
-export const WithActions: Story = {
+export const HeaderSubtitleAndActions: Story = {
+  parameters: { layout: 'fullscreen' },
+  render: (args) => (
+    <GApplication>
+      <GCard {...args}>
+        {{
+          header: () => <>This is the title</>,
+          subtitle: () => <>This is a subtitle</>,
+          actions: () => <>
+            <GButton color="primary">Nais</GButton>
+            <GButton color="secondary">Double Nais</GButton>
+          </>,
+        }}
+      </GCard>
+    </GApplication>
+  ),
+};
+
+export const HeaderSubtitleContentAndActions: Story = {
   parameters: { layout: 'fullscreen' },
   render: (args) => (
     <GApplication>
@@ -65,6 +110,22 @@ export const WithActions: Story = {
           header: () => <>This is the title</>,
           subtitle: () => <>This is a subtitle</>,
           content: () => <>This is the content of the card. It usually is quite large.</>,
+          actions: () => <>
+            <GButton color="primary">Nais</GButton>
+            <GButton color="secondary">Double Nais</GButton>
+          </>,
+        }}
+      </GCard>
+    </GApplication>
+  ),
+};
+
+export const OnlyActions: Story = {
+  parameters: { layout: 'fullscreen' },
+  render: (args) => (
+    <GApplication>
+      <GCard {...args}>
+        {{
           actions: () => <>
             <GButton color="primary">Nais</GButton>
             <GButton color="secondary">Double Nais</GButton>

--- a/src/components/card/GCard.vue
+++ b/src/components/card/GCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { GGlass } from '@/components/glass';
+import { GSeparator } from '@/components/separator';
 
 const slots = defineSlots<{
   default?(props: Record<string, never>): unknown,
@@ -13,30 +14,37 @@ const slots = defineSlots<{
 <template>
   <GGlass class="g-card">
     <div
-      v-if="slots.header"
-      class="g-card__header"
+      v-if="slots.header || slots.subtitle || slots.default || slots.content"
+      class="g-card__body"
     >
-      <slot name="header" />
+      <div
+        v-if="slots.header"
+        class="g-card__header"
+      >
+        <slot name="header" />
+      </div>
+      <div
+        v-if="slots.subtitle"
+        class="g-card__subtitle"
+      >
+        <slot name="subtitle" />
+      </div>
+      <GSeparator v-if="(slots.header || slots.subtitle) && (slots.default || slots.content)" />
+      <div
+        v-if="slots.default || slots.content"
+        class="g-card__content"
+      >
+        <slot
+          v-if="slots.content"
+          name="content"
+        />
+        <slot
+          v-else
+          name="default"
+        />
+      </div>
     </div>
-    <div
-      v-if="slots.subtitle"
-      class="g-card__subtitle"
-    >
-      <slot name="subtitle" />
-    </div>
-    <div
-      v-if="slots.default || slots.content"
-      class="g-card__content"
-    >
-      <slot
-        v-if="slots.content"
-        name="content"
-      />
-      <slot
-        v-else
-        name="default"
-      />
-    </div>
+    <GSeparator v-if="!(slots.header || slots.subtitle || slots.default || slots.content)" />
     <div
       v-if="slots.actions"
       class="g-card__actions"
@@ -55,12 +63,15 @@ const slots = defineSlots<{
   color: variables.$text-color;
 }
 
+.g-card__body {
+  padding: variables.$card-body-padding;
+}
+
 .g-card__header {
   font-size: variables.$card-header-font-size;
   font-weight: variables.$card-header-font-weight;
   letter-spacing: variables.$card-header-letter-spacing;
   line-height: variables.$card-header-line-height;
-  padding: variables.$card-header-padding;
 }
 
 .g-card__subtitle {
@@ -69,7 +80,6 @@ const slots = defineSlots<{
   letter-spacing: variables.$card-subtitle-letter-spacing;
   line-height: variables.$card-subtitle-line-height;
   opacity: variables.$card-subtitle-opacity;
-  padding: variables.$card-subtitle-padding;
 }
 
 .g-card__content {
@@ -77,7 +87,6 @@ const slots = defineSlots<{
   font-weight: variables.$card-content-font-weight;
   letter-spacing: variables.$card-content-letter-spacing;
   line-height: variables.$card-content-line-height;
-  padding: variables.$card-content-padding;
 }
 
 .g-card__actions {

--- a/src/components/card/_variables.scss
+++ b/src/components/card/_variables.scss
@@ -5,12 +5,14 @@
 // Colors
 $text-color: colors.$gray-100;
 
+// Body
+$card-body-padding: 1rem;
+
 // Header
 $card-header-font-size: tools.map-deep-get(fonts.$fonts, "h6", "size");
 $card-header-font-weight: tools.map-deep-get(fonts.$fonts, "h6", "weight");
 $card-header-letter-spacing: tools.map-deep-get(fonts.$fonts, "h6", "letter-spacing");
 $card-header-line-height: tools.map-deep-get(fonts.$fonts, "h6", "line-height");
-$card-header-padding: 1rem 1rem 0;
 
 // Subtitle
 $card-subtitle-font-size: tools.map-deep-get(fonts.$fonts, "body-2", "size");
@@ -18,14 +20,12 @@ $card-subtitle-font-weight: tools.map-deep-get(fonts.$fonts, "body-2", "weight")
 $card-subtitle-letter-spacing: tools.map-deep-get(fonts.$fonts, "body-2", "letter-spacing");
 $card-subtitle-line-height: tools.map-deep-get(fonts.$fonts, "body-2", "line-height");
 $card-subtitle-opacity: 0.6;
-$card-subtitle-padding: 0 1rem;
 
 // Content
 $card-content-font-size: tools.map-deep-get(fonts.$fonts, "body-2", "size");
 $card-content-font-weight: tools.map-deep-get(fonts.$fonts, "body-2", "weight");
 $card-content-letter-spacing: tools.map-deep-get(fonts.$fonts, "body-2", "letter-spacing");
 $card-content-line-height: tools.map-deep-get(fonts.$fonts, "body-2", "line-height");
-$card-content-padding: 1rem;
 
 // Actions
 $card-actions-padding: 0 1rem 1rem 1rem;

--- a/src/components/main.ts
+++ b/src/components/main.ts
@@ -4,3 +4,4 @@ export * from './card';
 export * from './glass';
 export * from './input';
 export * from './modal';
+export * from './separator';

--- a/src/components/separator/GSeparator.stories.tsx
+++ b/src/components/separator/GSeparator.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import { GApplication } from '@/components/application';
+import { GSeparator } from './index';
+
+// Auxiliar Types
+type Story = StoryObj<typeof GSeparator>;
+
+// Meta
+const meta: Meta<typeof GSeparator> = {
+  title: 'components/GSeparator',
+  component: GSeparator,
+  parameters: { controls: { sort: 'requiredFirst' } },
+};
+
+export default meta;
+
+// Base Stories
+const BaseStory = (height: number): Story => ({
+  parameters: { layout: 'fullscreen' },
+  render: (args) => (
+    <GApplication>
+      <div>This is some text!</div>
+      <GSeparator {...args} height={height} />
+      <div>This is some more text!</div>
+    </GApplication>
+  ),
+});
+
+// Exported Stories
+export const NoSeparator: Story = {
+  parameters: { layout: 'fullscreen' },
+  render: () => (
+    <GApplication>
+      <div>This is some text!</div>
+      <div>This is some more text!</div>
+    </GApplication>
+  ),
+};
+export const OneSeparator: Story = BaseStory(1);
+export const TwoSeparator: Story = BaseStory(2);
+export const ThreeSeparator: Story = BaseStory(3);
+export const FourSeparator: Story = BaseStory(4);
+export const TenSeparator: Story = BaseStory(10);

--- a/src/components/separator/GSeparator.vue
+++ b/src/components/separator/GSeparator.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+const props = withDefaults(defineProps<{
+    height?: number,
+  }>(), {
+  height: 1,
+});
+</script>
+
+<template>
+  <hr class="g-separator">
+</template>
+
+<style scoped lang="scss">
+@use "./variables";
+
+.g-separator {
+  border: none;
+  height: calc(variables.$separator-height * v-bind('props.height'));
+}
+</style>

--- a/src/components/separator/_variables.scss
+++ b/src/components/separator/_variables.scss
@@ -1,0 +1,1 @@
+$separator-height: 1rem;

--- a/src/components/separator/index.ts
+++ b/src/components/separator/index.ts
@@ -1,0 +1,4 @@
+import GSeparator from './GSeparator.vue';
+
+export { GSeparator };
+export type GSeparator = InstanceType<typeof GSeparator>;


### PR DESCRIPTION
## Description

Some content distribution would break the card layout (for example, cards with only actions, or cards without content but with titles and actions). This PR fixes those layouts.

This PR also adds the `GSeparator` component. It can be used to separate elements vertically.

## Requirements

None.

## Additional changes

None.
