### PR TITLE
Fix application component behaviour

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,4 @@
+# Auto-generated stuff
+dist
+storybook-static
+node_modules

--- a/src/components/application/GApplication.vue
+++ b/src/components/application/GApplication.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
+import { useViewHeight } from '@/composables/viewHeight';
+
 defineSlots<{
   default(props: Record<string, never>): unknown,
 }>();
+
+const { viewHeight } = useViewHeight();
 </script>
 
 <template>
@@ -23,7 +27,7 @@ defineSlots<{
 .g-application {
   position: absolute;
   width: 100vw;
-  height: 100vh;
+  height: v-bind(viewHeight);
   overflow: hidden;
   color: variables.$text-color;
   background-color: variables.$background-base;

--- a/src/composables/viewHeight.ts
+++ b/src/composables/viewHeight.ts
@@ -1,0 +1,30 @@
+/**
+ * A hack to be able to use the view height attribute
+ * when on mobile and avoid weird overflow bugs.
+ */
+
+import {
+  computed,
+  onMounted,
+  onUnmounted,
+  ref,
+} from 'vue';
+
+const rawViewHeight = ref(window.innerHeight);
+
+export const useViewHeight = () => {
+  const setViewHeight = () => {
+    rawViewHeight.value = window.innerHeight;
+  };
+
+  onMounted(() => {
+    window.addEventListener('resize', setViewHeight);
+  });
+  onUnmounted(() => {
+    window.removeEventListener('resize', setViewHeight);
+  });
+
+  const viewHeight = computed(() => `${rawViewHeight.value}px`);
+
+  return { rawViewHeight, viewHeight };
+};

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -1,5 +1,10 @@
+@use "./tokens/raw/colors";
 @use "./tokens/raw/fonts";
 
 :root {
   font-family: fonts.$typeface;
+}
+
+body {
+  background-color: colors.$gray-1000;
 }

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -27,5 +27,6 @@ module.exports = {
     'scss/at-rule-no-unknown': true,
     'selector-class-pattern': null,
     'number-max-precision': null,
+    'value-keyword-case': ['lower', { ignoreFunctions: ['v-bind'] }],
   },
 };


### PR DESCRIPTION
## Description

The application component behaved weirdly on iOS mobile devices. This PR fixes that using a small _hack_. It also adds a default color to the `body` of the HTML.

## Requirements

None.

## Additional changes

Stylelint now ignores the same stuff as ESLint. Also, Stylelint won't be angry when variables inside `v-bind` are not using `kebab-case`.
