### PR TITLE
Fix modal min width breakpoint

### DIFF
--- a/src/components/modal/GModal.vue
+++ b/src/components/modal/GModal.vue
@@ -103,7 +103,7 @@ onClickOutside(modalRef, () => {
   transition: variables.$modal-transition;
 }
 
-@media only screen and (width >= 600px) {
+@media only screen and (width <= 600px) {
   .g-modal__modal {
     min-width: calc(100% - #{variables.$modal-mobile-margin * 2});
     max-width: calc(100% - #{variables.$modal-mobile-margin * 2});


### PR DESCRIPTION
## Description

The breakpoint was set to when the width was greater than `600px` instead of lesser than. This PR fixes that.

## Requirements

None.

## Additional changes

None.
