### PR TITLE
Add footer slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Then, open your browser on `http://localhost:6006`.
 
 ## Using the Playground
 
-You can visually test your components by using the Playground provided by this project. On a new terminal, `cd` into `playground`, run `pnpm ci` and use `pnpm run dev` to start the Playground. You can learn more about this development aid by reading [its `README.md` file](./playground/README.md).
+You can visually test your components by using the Playground provided by this project. On a new terminal, `cd` into `playground`, run `pnpm install --frozen-lockfile` and use `pnpm run dev` to start the Playground. You can learn more about this development aid by reading [its `README.md` file](./playground/README.md).
 
 ## Developing with an external project
 

--- a/playground/README.md
+++ b/playground/README.md
@@ -9,7 +9,7 @@ Inside the `src` sub-folder you will find a `GPlayground.template.vue` file. Cop
 To start the Playground, first install the dependencies:
 
 ```sh
-pnpm ci
+pnpm install --frozen-lockfile
 ```
 
 Make sure the `src/GPlayground.vue` component exists. If it doesn't, create it by running the following code snippet:

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -3,7 +3,7 @@ import { GApplication } from '@/components/main';
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: This will always fail on a clean repository
-import GPlayground from './GPlayground.vue';
+import GPlayground from './GPlayground.vue'; // eslint-disable-line import/no-unresolved
 </script>
 
 <template>

--- a/src/components/application/GApplication.vue
+++ b/src/components/application/GApplication.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { useViewHeight } from '@/composables/viewHeight';
+import { GGlass } from '@/components/glass';
 
-defineSlots<{
+const slots = defineSlots<{
   default(props: Record<string, never>): unknown,
+  footer?(props: Record<string, never>): unknown,
 }>();
 
 const { viewHeight } = useViewHeight();
@@ -17,6 +19,14 @@ const { viewHeight } = useViewHeight();
       >
         <slot name="default" />
       </div>
+      <GGlass
+        v-if="slots.footer"
+        :border-radius="0"
+      >
+        <div class="g-application__footer">
+          <slot name="footer" />
+        </div>
+      </GGlass>
     </div>
   </div>
 </template>
@@ -37,6 +47,9 @@ const { viewHeight } = useViewHeight();
 }
 
 .g-application__scroll {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
   overflow-y: auto;
   width: 100%;
   height: 100%;
@@ -47,5 +60,9 @@ const { viewHeight } = useViewHeight();
   flex-direction: column;
   flex: 1 1 auto;
   padding: variables.$application-padding;
+}
+
+.g-application__footer {
+  padding: variables.$footer-padding;
 }
 </style>

--- a/src/components/application/_variables.scss
+++ b/src/components/application/_variables.scss
@@ -6,6 +6,12 @@ $text-color: colors.$gray-100;
 $background-base: colors.$gray-1000;
 $background-accent-1: color.change(colors.$purple-900, $alpha: 0.5);
 $background-accent-2: color.change(colors.$sky-blue-900, $alpha: 0.6);
+$link-color: colors.$sky-blue-600;
+$link-visited-color: colors.$sky-blue-700;
 
 // Spacing
 $application-padding: 1rem;
+
+// Footer
+$footer-padding: 2rem 1rem;
+$footer-background: color.change(colors.$gray-1000, $alpha: 0.5);

--- a/src/components/glass/GGlass.stories.tsx
+++ b/src/components/glass/GGlass.stories.tsx
@@ -14,8 +14,8 @@ const meta = {
 
 export default meta;
 
-// Exported Stories
-export const Glass = {
+// Base Stories
+const BaseStory = () => ({
   parameters: { layout: 'fullscreen' },
   render: (args) => (
     <GApplication style={{ display: 'block' }} >
@@ -29,4 +29,19 @@ export const Glass = {
       </GGlass>
     </GApplication>
   ),
+} satisfies Story);
+
+// Exported Stories
+export const Glass = {
+  ...BaseStory(),
+  args: {
+    borderRadius: 1,
+  },
 } satisfies Story;
+
+export const SquaredGlass = {
+  ...BaseStory(),
+  args: {
+    borderRadius: 0,
+  },
+};

--- a/src/components/glass/GGlass.vue
+++ b/src/components/glass/GGlass.vue
@@ -1,7 +1,17 @@
 <script setup lang="ts">
+import { computed } from 'vue';
+
 defineSlots<{
   default(props: Record<string, never>): unknown,
 }>();
+
+const props = withDefaults(defineProps<{
+  borderRadius?: number,
+}>(), {
+  borderRadius: 1,
+});
+
+const borderRadius = computed(() => `${props.borderRadius}rem`);
 </script>
 
 <template>
@@ -17,7 +27,7 @@ defineSlots<{
   display: inline-block;
   position: relative;
   padding: 0;
-  border-radius: 1rem;
+  border-radius: v-bind(borderRadius);
   background-color: variables.$glass-background-color;
   backdrop-filter: blur(1rem) saturate(180%);
   border: 1px solid variables.$glass-border-color;

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -11,4 +11,12 @@ body {
   background-image:
     radial-gradient(at 72% 33%, application.$background-accent-1 0, transparent 49%),
     radial-gradient(at 31% 60%, application.$background-accent-2 0, transparent 55%);
+
+  a {
+    color: application.$link-color;
+
+    &:visited {
+      color: application.$link-visited-color;
+    }
+  }
 }


### PR DESCRIPTION
## Description

There is now a `footer` slot for the `GApplication` component, where the application will add a footer.

## Requirements

None.

## Additional changes

The `GGlass` component can now have its `border-radius` controlled. It defaults to `1rem`, same as before. Also, links are now correctly colored through the application.
