### PR TITLE
Add text components

### DIFF
--- a/src/components/button/GButton.stories.tsx
+++ b/src/components/button/GButton.stories.tsx
@@ -27,6 +27,7 @@ const BaseStory = (slots: { default?: () => JSX.Element, icon?: () => JSX.Elemen
   render: (args) => (
     <GApplication>
       <div>
+        {/* @ts-expect-error: missmatch on component typing between .vue and .tsx */}
         <GButton {...args} onClick={onClickAction}>
           { slots }
         </GButton>

--- a/src/components/button/_variables.scss
+++ b/src/components/button/_variables.scss
@@ -1,13 +1,5 @@
-@use "@/styles/tools";
 @use "@/styles/tokens/raw/colors";
-@use "@/styles/tokens/settings/fonts";
 
 // Colors
 $primary-color: colors.$purple-600;
 $secondary-color: colors.$sky-blue-600;
-
-// Text
-$button-font-size: tools.map-deep-get(fonts.$fonts, "button", "size");
-$button-font-weight: tools.map-deep-get(fonts.$fonts, "button", "weight");
-$button-letter-spacing: tools.map-deep-get(fonts.$fonts, "button", "letter-spacing");
-$button-line-height: tools.map-deep-get(fonts.$fonts, "button", "line-height");

--- a/src/components/button/types.ts
+++ b/src/components/button/types.ts
@@ -1,2 +1,2 @@
-export const colors = ['primary', 'secondary'];
+export const colors = ['primary', 'secondary'] as const;
 export type Color = typeof colors[number];

--- a/src/components/card/GCard.vue
+++ b/src/components/card/GCard.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { GGlass } from '@/components/glass';
+import { GHeading } from '@/components/heading';
 import { GSeparator } from '@/components/separator';
+import { GText } from '@/components/text';
 
 const slots = defineSlots<{
   default?(props: Record<string, never>): unknown,
@@ -17,22 +19,23 @@ const slots = defineSlots<{
       v-if="slots.header || slots.subtitle || slots.default || slots.content"
       class="g-card__body"
     >
-      <div
+      <GHeading
         v-if="slots.header"
-        class="g-card__header"
+        type="h6"
       >
         <slot name="header" />
-      </div>
-      <div
+      </GHeading>
+      <GText
         v-if="slots.subtitle"
+        type="body-2"
         class="g-card__subtitle"
       >
         <slot name="subtitle" />
-      </div>
+      </GText>
       <GSeparator v-if="(slots.header || slots.subtitle) && (slots.default || slots.content)" />
-      <div
+      <GText
         v-if="slots.default || slots.content"
-        class="g-card__content"
+        type="body-2"
       >
         <slot
           v-if="slots.content"
@@ -42,7 +45,7 @@ const slots = defineSlots<{
           v-else
           name="default"
         />
-      </div>
+      </GText>
     </div>
     <GSeparator v-if="!(slots.header || slots.subtitle || slots.default || slots.content)" />
     <div
@@ -67,26 +70,8 @@ const slots = defineSlots<{
   padding: variables.$card-body-padding;
 }
 
-.g-card__header {
-  font-size: variables.$card-header-font-size;
-  font-weight: variables.$card-header-font-weight;
-  letter-spacing: variables.$card-header-letter-spacing;
-  line-height: variables.$card-header-line-height;
-}
-
 .g-card__subtitle {
-  font-size: variables.$card-subtitle-font-size;
-  font-weight: variables.$card-subtitle-font-weight;
-  letter-spacing: variables.$card-subtitle-letter-spacing;
-  line-height: variables.$card-subtitle-line-height;
   opacity: variables.$card-subtitle-opacity;
-}
-
-.g-card__content {
-  font-size: variables.$card-content-font-size;
-  font-weight: variables.$card-content-font-weight;
-  letter-spacing: variables.$card-content-letter-spacing;
-  line-height: variables.$card-content-line-height;
 }
 
 .g-card__actions {

--- a/src/components/card/_variables.scss
+++ b/src/components/card/_variables.scss
@@ -8,24 +8,8 @@ $text-color: colors.$gray-100;
 // Body
 $card-body-padding: 1rem;
 
-// Header
-$card-header-font-size: tools.map-deep-get(fonts.$fonts, "h6", "size");
-$card-header-font-weight: tools.map-deep-get(fonts.$fonts, "h6", "weight");
-$card-header-letter-spacing: tools.map-deep-get(fonts.$fonts, "h6", "letter-spacing");
-$card-header-line-height: tools.map-deep-get(fonts.$fonts, "h6", "line-height");
-
 // Subtitle
-$card-subtitle-font-size: tools.map-deep-get(fonts.$fonts, "body-2", "size");
-$card-subtitle-font-weight: tools.map-deep-get(fonts.$fonts, "body-2", "weight");
-$card-subtitle-letter-spacing: tools.map-deep-get(fonts.$fonts, "body-2", "letter-spacing");
-$card-subtitle-line-height: tools.map-deep-get(fonts.$fonts, "body-2", "line-height");
 $card-subtitle-opacity: 0.6;
-
-// Content
-$card-content-font-size: tools.map-deep-get(fonts.$fonts, "body-2", "size");
-$card-content-font-weight: tools.map-deep-get(fonts.$fonts, "body-2", "weight");
-$card-content-letter-spacing: tools.map-deep-get(fonts.$fonts, "body-2", "letter-spacing");
-$card-content-line-height: tools.map-deep-get(fonts.$fonts, "body-2", "line-height");
 
 // Actions
 $card-actions-padding: 0 1rem 1rem 1rem;

--- a/src/components/heading/GHeading.stories.tsx
+++ b/src/components/heading/GHeading.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import { GApplication } from '@/components/application';
+import { GSeparator } from '@/components/separator';
+import { headingTypes } from './types';
+import { GHeading } from './index';
+
+// Auxiliar Types
+type Story = StoryObj<typeof GHeading>;
+
+// Meta
+const meta = {
+  title: 'components/GHeading',
+  component: GHeading,
+  parameters: { controls: { sort: 'requiredFirst' } },
+  argTypes: {
+    type: { options: headingTypes },
+  },
+} satisfies Meta<typeof GHeading>;
+
+export default meta;
+
+// Exported Stories
+export const DefaultHeading = {
+  render: () => (
+    <GApplication>
+      <GHeading>Geometr default heading (H3)</GHeading>
+    </GApplication>
+  ),
+} satisfies Story;
+
+export const Headings = {
+  render: () => (
+    <GApplication>
+      <GHeading type="h1">Geometr H1 heading</GHeading>
+      <GSeparator height={2} />
+      <GHeading type="h2">Geometr H2 heading</GHeading>
+      <GSeparator height={2} />
+      <GHeading type="h3">Geometr H3 heading</GHeading>
+      <GSeparator height={2} />
+      <GHeading type="h4">Geometr H4 heading</GHeading>
+      <GSeparator height={2} />
+      <GHeading type="h5">Geometr H5 heading</GHeading>
+      <GSeparator height={2} />
+      <GHeading type="h6">Geometr H6 heading</GHeading>
+    </GApplication>
+  ),
+} satisfies Story;

--- a/src/components/heading/GHeading.vue
+++ b/src/components/heading/GHeading.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import type { HeadingType } from './types';
+
+defineSlots<{ default(props: Record<string, never>): unknown }>();
+
+const props = withDefaults(defineProps<{
+  type?: HeadingType,
+}>(), {
+  type: 'h3',
+});
+</script>
+
+<template>
+  <component
+    :is="props.type"
+    :class="`g-${props.type}`"
+  >
+    <slot />
+  </component>
+</template>
+
+<style scoped lang="scss">
+@use "./variables";
+
+.g-h1 {
+  font-size: variables.$h1-font-size;
+  font-weight: variables.$h1-font-weight;
+  line-height: variables.$h1-line-height;
+  letter-spacing: variables.$h1-letter-spacing;
+}
+
+.g-h2 {
+  font-size: variables.$h2-font-size;
+  font-weight: variables.$h2-font-weight;
+  line-height: variables.$h2-line-height;
+  letter-spacing: variables.$h2-letter-spacing;
+}
+
+.g-h3 {
+  font-size: variables.$h3-font-size;
+  font-weight: variables.$h3-font-weight;
+  line-height: variables.$h3-line-height;
+  letter-spacing: variables.$h3-letter-spacing;
+}
+
+.g-h4 {
+  font-size: variables.$h4-font-size;
+  font-weight: variables.$h4-font-weight;
+  line-height: variables.$h4-line-height;
+  letter-spacing: variables.$h4-letter-spacing;
+}
+
+.g-h5 {
+  font-size: variables.$h5-font-size;
+  font-weight: variables.$h5-font-weight;
+  line-height: variables.$h5-line-height;
+  letter-spacing: variables.$h5-letter-spacing;
+}
+
+.g-h6 {
+  font-size: variables.$h6-font-size;
+  font-weight: variables.$h6-font-weight;
+  line-height: variables.$h6-line-height;
+  letter-spacing: variables.$h6-letter-spacing;
+}
+</style>

--- a/src/components/heading/_variables.scss
+++ b/src/components/heading/_variables.scss
@@ -1,0 +1,38 @@
+@use "@/styles/tools";
+@use "@/styles/tokens/settings/fonts";
+
+// H1
+$h1-font-size: tools.map-deep-get(fonts.$fonts, "h1", "size");
+$h1-font-weight: tools.map-deep-get(fonts.$fonts, "h1", "weight");
+$h1-line-height: tools.map-deep-get(fonts.$fonts, "h1", "line-height");
+$h1-letter-spacing: tools.map-deep-get(fonts.$fonts, "h1", "letter-spacing");
+
+// H2
+$h2-font-size: tools.map-deep-get(fonts.$fonts, "h2", "size");
+$h2-font-weight: tools.map-deep-get(fonts.$fonts, "h2", "weight");
+$h2-line-height: tools.map-deep-get(fonts.$fonts, "h2", "line-height");
+$h2-letter-spacing: tools.map-deep-get(fonts.$fonts, "h2", "letter-spacing");
+
+// H3
+$h3-font-size: tools.map-deep-get(fonts.$fonts, "h3", "size");
+$h3-font-weight: tools.map-deep-get(fonts.$fonts, "h3", "weight");
+$h3-line-height: tools.map-deep-get(fonts.$fonts, "h3", "line-height");
+$h3-letter-spacing: tools.map-deep-get(fonts.$fonts, "h3", "letter-spacing");
+
+// H4
+$h4-font-size: tools.map-deep-get(fonts.$fonts, "h4", "size");
+$h4-font-weight: tools.map-deep-get(fonts.$fonts, "h4", "weight");
+$h4-line-height: tools.map-deep-get(fonts.$fonts, "h4", "line-height");
+$h4-letter-spacing: tools.map-deep-get(fonts.$fonts, "h4", "letter-spacing");
+
+// H5
+$h5-font-size: tools.map-deep-get(fonts.$fonts, "h5", "size");
+$h5-font-weight: tools.map-deep-get(fonts.$fonts, "h5", "weight");
+$h5-line-height: tools.map-deep-get(fonts.$fonts, "h5", "line-height");
+$h5-letter-spacing: tools.map-deep-get(fonts.$fonts, "h5", "letter-spacing");
+
+// H6
+$h6-font-size: tools.map-deep-get(fonts.$fonts, "h6", "size");
+$h6-font-weight: tools.map-deep-get(fonts.$fonts, "h6", "weight");
+$h6-line-height: tools.map-deep-get(fonts.$fonts, "h6", "line-height");
+$h6-letter-spacing: tools.map-deep-get(fonts.$fonts, "h6", "letter-spacing");

--- a/src/components/heading/index.ts
+++ b/src/components/heading/index.ts
@@ -1,0 +1,4 @@
+import GHeading from './GHeading.vue';
+
+export { GHeading };
+export type GHeading = InstanceType<typeof GHeading>;

--- a/src/components/heading/types.ts
+++ b/src/components/heading/types.ts
@@ -1,0 +1,2 @@
+export const headingTypes = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const;
+export type HeadingType = typeof headingTypes[number];

--- a/src/components/main.ts
+++ b/src/components/main.ts
@@ -2,6 +2,8 @@ export * from './application';
 export * from './button';
 export * from './card';
 export * from './glass';
+export * from './heading';
 export * from './input';
 export * from './modal';
 export * from './separator';
+export * from './text';

--- a/src/components/modal/GModal.stories.tsx
+++ b/src/components/modal/GModal.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/vue3';
 import { GApplication } from '@/components/application';
 import { GButton } from '@/components/button';
+import { GText } from '@/components/text';
 import { useModal } from '@/composables/modal';
 import { GModal } from './index';
 
@@ -24,6 +25,7 @@ const BaseStory = (slots: { default: () => JSX.Element, title?: () => JSX.Elemen
     return (
       <GApplication>
         <div>
+          {/* @ts-expect-error: missmatch on component typing between .vue and .tsx */}
           <GButton onClick={open}>
             Open!
           </GButton>
@@ -40,14 +42,14 @@ const BaseStory = (slots: { default: () => JSX.Element, title?: () => JSX.Elemen
 export const ModalWithContent = {
   ...BaseStory({
     title: () => <>Some Title</>,
-    default: () => <>This is a modal!</>,
+    default: () => <GText>This is a modal!</GText>,
   }),
 } satisfies Story;
 
 export const ModalWithLargeContent = {
   ...BaseStory({
     title: () => <>Some Title</>,
-    default: () => <>
+    default: () => <GText>
       This is a modal! Lorem ipsum dolor sit amet, consectetur adipiscing elit.
       Mauris imperdiet porttitor odio vel viverra. Sed cursus gravida enim et mattis.
       Vivamus eu velit tempus, ullamcorper metus vitae, iaculis libero.
@@ -56,13 +58,13 @@ export const ModalWithLargeContent = {
       Duis gravida erat id lectus tristique rutrum.
       Praesent vitae faucibus tellus.
       Mauris eu mauris egestas, consectetur lectus et, semper dolor.
-    </>,
+    </GText>,
   }),
 } satisfies Story;
 
 export const PersistentModalWithContent = {
   ...BaseStory({
-    default: () => <>This is a modal!</>,
+    default: () => <GText>This is a modal!</GText>,
   }),
   args: {
     persistent: true,

--- a/src/components/modal/GModal.vue
+++ b/src/components/modal/GModal.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue';
 import { onClickOutside } from '@vueuse/core';
 import { GGlass } from '@/components/glass';
+import { GHeading } from '@/components/heading';
 
 defineSlots<{
   title?(props: Record<string, never>): unknown,
@@ -42,20 +43,21 @@ onClickOutside(modalRef, () => {
               ref="modalRef"
               class="g-modal__modal"
             >
-              <div
+              <GHeading
                 v-if="!props.persistent"
+                type="h6"
                 class="g-modal__header"
               >
-                <div class="g-modal__header--title">
+                <span class="g-modal__header--title">
                   <slot name="title" />
-                </div>
-                <div
+                </span>
+                <span
                   class="g-modal__header--close"
                   @click="closeModal"
                 >
                   <span class="mdi mdi-window-close" />
-                </div>
-              </div>
+                </span>
+              </GHeading>
               <div class="g-modal__content">
                 <slot name="default" />
               </div>
@@ -113,10 +115,6 @@ onClickOutside(modalRef, () => {
 .g-modal__header {
   display: flex;
   justify-content: space-between;
-  font-size: variables.$modal-header-font-size;
-  font-weight: variables.$modal-header-font-weight;
-  letter-spacing: variables.$modal-header-letter-spacing;
-  line-height: variables.$modal-header-line-height;
   padding: variables.$modal-header-padding;
   border-bottom: variables.$modal-header-border-bottom;
 }

--- a/src/components/modal/_variables.scss
+++ b/src/components/modal/_variables.scss
@@ -17,10 +17,6 @@ $modal-transition: all 0.3s ease;
 // Header
 $modal-header-padding: 0.3rem 2rem;
 $modal-header-border-bottom: 1px solid colors.$gray-700;
-$modal-header-font-size: tools.map-deep-get(fonts.$fonts, "h6", "size");
-$modal-header-font-weight: tools.map-deep-get(fonts.$fonts, "h6", "weight");
-$modal-header-letter-spacing: tools.map-deep-get(fonts.$fonts, "h6", "letter-spacing");
-$modal-header-line-height: tools.map-deep-get(fonts.$fonts, "h6", "line-height");
 
 // Content
 $modal-content-padding: 1.5rem 2rem;

--- a/src/components/separator/GSeparator.vue
+++ b/src/components/separator/GSeparator.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 const props = withDefaults(defineProps<{
-    height?: number,
-  }>(), {
+  height?: number,
+}>(), {
   height: 1,
 });
 </script>

--- a/src/components/text/GText.stories.tsx
+++ b/src/components/text/GText.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import { GApplication } from '@/components/application';
+import { GSeparator } from '@/components/separator';
+import { textTags, textTypes } from './types';
+import { GText } from './index';
+
+// Auxiliar Types
+type Story = StoryObj<typeof GText>;
+
+// Meta
+const meta = {
+  title: 'components/GText',
+  component: GText,
+  parameters: { controls: { sort: 'requiredFirst' } },
+  argTypes: {
+    is: { options: textTags },
+    type: { options: textTypes },
+  },
+} satisfies Meta<typeof GText>;
+
+export default meta;
+
+// Exported Stories
+export const DefaultText = {
+  render: () => (
+    <GApplication>
+      <GText>Geometr default text (body-1)</GText>
+    </GApplication>
+  ),
+} satisfies Story;
+
+export const StandardTexts = {
+  render: () => (
+    <GApplication>
+      <GText type="subtitle-1">Geometr Subtitle 1 text</GText>
+      <GSeparator />
+      <GText type="subtitle-2">Geometr Subtitle 2 text</GText>
+      <GSeparator />
+      <GText type="body-1">Geometr Body 1 text</GText>
+      <GSeparator />
+      <GText type="body-2">Geometr Body 2 text</GText>
+    </GApplication>
+  ),
+} satisfies Story;
+
+export const TextVariations = {
+  render: () => (
+    <GApplication>
+      <GText is="p">Geometr Paragraph</GText>
+      <GSeparator />
+      <GText is="span">Geometr Span</GText>
+      <GSeparator />
+      <GText is="b">Geometr Bold</GText>
+      <GSeparator />
+      <GText is="i">Geometr Italic</GText>
+      <GSeparator />
+      <GText is="u">Geometr Underline</GText>
+      <GSeparator />
+      <GText is="kbd">Geometr Ctrl + C</GText>
+      <GSeparator />
+      <GText is="s">Geometr Strikethrough</GText>
+      <GSeparator />
+    </GApplication>
+  ),
+} satisfies Story;

--- a/src/components/text/GText.vue
+++ b/src/components/text/GText.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import type { TextTag, TextType } from './types';
+
+defineSlots<{ default(props: Record<string, never>): unknown }>();
+
+const props = withDefaults(defineProps<{
+  is?: TextTag,
+  type?: TextType,
+}>(), {
+  is: 'p',
+  type: 'body-1',
+});
+</script>
+
+<template>
+  <component
+    :is="props.is"
+    :class="`g-${props.type}`"
+  >
+    <slot />
+  </component>
+</template>
+
+<style scoped lang="scss">
+@use "./variables";
+
+b {
+  font-weight: variables.$bold-font-weight !important;
+}
+
+.g-subtitle-1 {
+  font-size: variables.$subtitle-1-font-size;
+  font-weight: variables.$subtitle-1-font-weight;
+  line-height: variables.$subtitle-1-line-height;
+  letter-spacing: variables.$subtitle-1-letter-spacing;
+  text-transform: variables.$subtitle-1-text-transform;
+}
+
+.g-subtitle-2 {
+  font-size: variables.$subtitle-2-font-size;
+  font-weight: variables.$subtitle-2-font-weight;
+  line-height: variables.$subtitle-2-line-height;
+  letter-spacing: variables.$subtitle-2-letter-spacing;
+  text-transform: variables.$subtitle-2-text-transform;
+}
+
+.g-body-1 {
+  font-size: variables.$body-1-font-size;
+  font-weight: variables.$body-1-font-weight;
+  line-height: variables.$body-1-line-height;
+  letter-spacing: variables.$body-1-letter-spacing;
+  text-transform: variables.$body-1-text-transform;
+}
+
+.g-body-2 {
+  font-size: variables.$body-2-font-size;
+  font-weight: variables.$body-2-font-weight;
+  line-height: variables.$body-2-line-height;
+  letter-spacing: variables.$body-2-letter-spacing;
+  text-transform: variables.$body-2-text-transform;
+}
+</style>

--- a/src/components/text/_variables.scss
+++ b/src/components/text/_variables.scss
@@ -1,0 +1,33 @@
+@use "@/styles/tools";
+@use "@/styles/tokens/settings/fonts";
+
+// Bold Tag
+$bold-font-weight: bolder;
+
+// Subtitle 1
+$subtitle-1-font-size: tools.map-deep-get(fonts.$fonts, "subtitle-1", "size");
+$subtitle-1-font-weight: tools.map-deep-get(fonts.$fonts, "subtitle-1", "weight");
+$subtitle-1-line-height: tools.map-deep-get(fonts.$fonts, "subtitle-1", "line-height");
+$subtitle-1-letter-spacing: tools.map-deep-get(fonts.$fonts, "subtitle-1", "letter-spacing");
+$subtitle-1-text-transform: tools.map-deep-get(fonts.$fonts, "subtitle-1", "text-transform");
+
+// Subtitle 2
+$subtitle-2-font-size: tools.map-deep-get(fonts.$fonts, "subtitle-2", "size");
+$subtitle-2-font-weight: tools.map-deep-get(fonts.$fonts, "subtitle-2", "weight");
+$subtitle-2-line-height: tools.map-deep-get(fonts.$fonts, "subtitle-2", "line-height");
+$subtitle-2-letter-spacing: tools.map-deep-get(fonts.$fonts, "subtitle-2", "letter-spacing");
+$subtitle-2-text-transform: tools.map-deep-get(fonts.$fonts, "subtitle-2", "text-transform");
+
+// Body 1
+$body-1-font-size: tools.map-deep-get(fonts.$fonts, "body-1", "size");
+$body-1-font-weight: tools.map-deep-get(fonts.$fonts, "body-1", "weight");
+$body-1-line-height: tools.map-deep-get(fonts.$fonts, "body-1", "line-height");
+$body-1-letter-spacing: tools.map-deep-get(fonts.$fonts, "body-1", "letter-spacing");
+$body-1-text-transform: tools.map-deep-get(fonts.$fonts, "body-1", "text-transform");
+
+// Body 2
+$body-2-font-size: tools.map-deep-get(fonts.$fonts, "body-2", "size");
+$body-2-font-weight: tools.map-deep-get(fonts.$fonts, "body-2", "weight");
+$body-2-line-height: tools.map-deep-get(fonts.$fonts, "body-2", "line-height");
+$body-2-letter-spacing: tools.map-deep-get(fonts.$fonts, "body-2", "letter-spacing");
+$body-2-text-transform: tools.map-deep-get(fonts.$fonts, "body-2", "text-transform");

--- a/src/components/text/index.ts
+++ b/src/components/text/index.ts
@@ -1,0 +1,4 @@
+import GText from './GText.vue';
+
+export { GText };
+export type GText = InstanceType<typeof GText>;

--- a/src/components/text/types.ts
+++ b/src/components/text/types.ts
@@ -1,0 +1,5 @@
+export const textTypes = ['subtitle-1', 'subtitle-2', 'body-1', 'body-2'] as const;
+export type TextType = typeof textTypes[number];
+
+export const textTags = ['p', 'span', 'b', 'i', 'u', 'kbd', 's'] as const;
+export type TextTag = typeof textTags[number];


### PR DESCRIPTION
## Description

This PR adds two new text components: `GHeading` for `h1 - h6` headings, and `GText`, for some other misc texts (`subtitle-1`, `subtitle-2`, `body-1` and `body-2`). It also uses those components throughout the existing components instead of using just CSS classes.

This PR should maintain the UI exactly the same.

## Requirements

None.

## Additional changes

None.
