### PR TITLE
Allow SSR usage

### DIFF
--- a/src/composables/viewHeight.ts
+++ b/src/composables/viewHeight.ts
@@ -10,7 +10,8 @@ import {
   ref,
 } from 'vue';
 
-const rawViewHeight = ref(window.innerHeight);
+const INITIAL_VIEW_HEIGHT = window?.innerHeight || 1000;
+const rawViewHeight = ref(INITIAL_VIEW_HEIGHT);
 
 export const useViewHeight = () => {
   const setViewHeight = () => {


### PR DESCRIPTION
## Description

The `useViewHeight` composable now has a default initial value for when the `window` object does not exist. I checked every other usage of `window` or `document`, and every other usage was inside an `onMounted` or an `onUnmounted` hook, so no problems there.

## Requirements

None.

## Additional changes

None.
