### PR TITLE
Fix SSR window usage

### DIFF
--- a/src/composables/viewHeight.ts
+++ b/src/composables/viewHeight.ts
@@ -9,8 +9,9 @@ import {
   onUnmounted,
   ref,
 } from 'vue';
+import { getWindow } from '@/utils/window';
 
-const INITIAL_VIEW_HEIGHT = window?.innerHeight || 1000;
+const INITIAL_VIEW_HEIGHT = getWindow()?.innerHeight || 1000;
 const rawViewHeight = ref(INITIAL_VIEW_HEIGHT);
 
 export const useViewHeight = () => {

--- a/src/utils/window.ts
+++ b/src/utils/window.ts
@@ -1,0 +1,1 @@
+export const getWindow = () => (typeof window === 'undefined' ? undefined : window);


### PR DESCRIPTION
## Description

The library now safely uses the `window` global variable outside of mounted hooks. If `typeof window` equals `'undefined'`, now `undefined` is used instead of `window`.

## Requirements

None.

## Additional changes

None.
