### PR TITLE
Release 0.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geometr",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "type": "module",
   "main": "./dist/main.cjs.js",
   "module": "./dist/main.es.js",

--- a/src/composables/viewHeight.ts
+++ b/src/composables/viewHeight.ts
@@ -9,8 +9,9 @@ import {
   onUnmounted,
   ref,
 } from 'vue';
+import { getWindow } from '@/utils/window';
 
-const INITIAL_VIEW_HEIGHT = window?.innerHeight || 1000;
+const INITIAL_VIEW_HEIGHT = getWindow()?.innerHeight || 1000;
 const rawViewHeight = ref(INITIAL_VIEW_HEIGHT);
 
 export const useViewHeight = () => {

--- a/src/utils/window.ts
+++ b/src/utils/window.ts
@@ -1,0 +1,1 @@
+export const getWindow = () => (typeof window === 'undefined' ? undefined : window);


### PR DESCRIPTION
# Version 0.6.2 🎉

## Fixes 🐛

- The `window` object now gets fetched with a method that returns `undefined` if `window` is not defined.
